### PR TITLE
Convert rejected Promises into exceptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,17 +75,25 @@
 	};
 
 	module.exports.await = function(pr) {
-		var done, result;
-
-		done = false;
-		result = undefined;
+		var done = false;
+		var rejected = false;
+		var resolutionResult = undefined;
+		var rejectionResult = undefined;
 
 		pr.then(function(r) {
-			done   = true;
-			return result = r;
+			done = true;
+			resolutionResult = r;
+		}).catch(function(e) {
+			done = true;
+			rejected = true;
+			rejectionResult = e;
 		});
 		deasync.loopWhile(() => { return !done });
-		return result;
+
+		if (rejected) {
+			throw rejectionResult;
+		}
+		return resolutionResult;
 	};
 
 }());

--- a/test.js
+++ b/test.js
@@ -43,3 +43,9 @@ async function trim(str) {
 }
 
 console.log(deasync.await(trim('       hello       ')))
+
+try {
+  deasync.await(Promise.reject("Should result in exception"));
+} catch(e) {
+  console.log("Got expected exception:", e);
+}


### PR DESCRIPTION
Without this change, rejected promises cause await to hang forever

```
$ node
> require('deasync2').await(Promise.reject(123))
(node:30509) UnhandledPromiseRejectionWarning: 123
(node:30509) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:30509) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
(node:30509) [DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated. Use the async_context variant of MakeCallback or the AsyncResource class instead.
```